### PR TITLE
Adjust deploy script when deploying all stacks

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -62,4 +62,4 @@ if [[ "${INPUT_CDK_STACK}" != '' ]]; then
 fi
 
 echo "Running action ${INPUT_CDK_ACTION} on default stack..."
-cdk ${INPUT_CDK_ACTION} -c env=${INPUT_CDK_ENV}
+cdk ${INPUT_CDK_ACTION} -c env=${INPUT_CDK_ENV} --all


### PR DESCRIPTION
Ticket: https://github.com/metriport/metriport-internal/issues/92

### Dependencies

- Upstream: none
- Downstream: none

### Description

Adjust deploy script when deploying all stacks, `-all` option.

### Release Plan

- not a release, anytime