### PR TITLE
npm ci w/ ignore script instead of install

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -41,7 +41,8 @@ echo "Installing INFRA dependencies..."
 pwd
 cd "${GITHUB_WORKSPACE}/infra"
 pwd
-npm install
+# With --ignore-scripts so we don't run the 'prepare' script (husky install)
+npm ci --ignore-scripts
 echo "...DONE INFRA dependencies"
 
 echo "CDK version: $(cdk --version)"


### PR DESCRIPTION
Ref https://github.com/metriport/metriport-internal/issues/143

### Dependencies

- Upstream: https://github.com/metriport/metriport-internal/pull/287
- Downstream: https://github.com/metriport/metriport-internal/pull/288

### Description

Issue `npm ci --ignore-scripts` on `./infra` instead of `npm install` to prevent husky from running on the root folder of the NPM workspace when these commands are issued in the `./infra` package.

### Release Plan

asap