### PR TITLE
feat: update action node version to 18.14

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version: "16"
+        node-version: "18.14"
     - run: echo "Env on action.yml:"
       shell: bash
     - run: env


### PR DESCRIPTION
Ref. metriport/metriport-internal#351

### Dependencies

- Upstream: none
- Downstream: https://github.com/metriport/metriport-internal/pull/358

### Description

Update Node version for the action, from 16 to 18.14 (the same used on the downstream PR)

### Release Plan

asap