### PR TITLE
Remove jonah from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Goncharo @leite08 @Orta21 @RamilGaripov @jonahkaye @thomasyopes
+* @Goncharo @leite08 @Orta21 @RamilGaripov @thomasyopes


### PR DESCRIPTION
Ref. metriport/metriport-internal#799

### Dependencies

none

### Description

Remove jonah from codeowners

### Release Plan

- [ ] Merge this
